### PR TITLE
Add option flags for information retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ response = requests.post('https://pesu-auth.herokuapp.com/', data=data)
 print(response.json())
 ```
 
-On authentication, it returns the following parameters in a JSON object. If the sign-in was successful, the response's 
+On authentication, it returns the following parameters in a JSON object. If the sign-in was successful and profile data was requested, the response's 
 `profile-data` key will store a dictionary with a user's profile information. On an unsuccessful sign-in, this field will hold an empty dictionary.
 
 ```json

--- a/app/main.py
+++ b/app/main.py
@@ -13,17 +13,21 @@ IST = pytz.timezone("Asia/Kolkata")
 def home():
     username = request.form.get("username")
     password = request.form.get("password")
+    get_profile_data = str(request.form.get("get_profile_data")).lower() == "true"
 
     login_status = False
     profile_data = dict()
     if username != None and password != None:
-        login_status, profile_data = authenticatePESU(username, password)
+        login_status, profile_data = authenticatePESU(username, password, get_profile_data)
 
     result = {
         "authentication-status": login_status,
         "timestamp": str(datetime.datetime.now(IST)),
-        "profile-data": profile_data
     }
+
+    if get_profile_data:
+        result["profile-data"] = profile_data
+
     result = json.dumps(result)
     return result, 200
 

--- a/app/utils.py
+++ b/app/utils.py
@@ -17,11 +17,11 @@ GOOGLE_CHROME_BIN = os.environ["GOOGLE_CHROME_BIN"]
 CHROMEDRIVER_PATH = os.environ["CHROMEDRIVER_PATH"]
 
 
-def authenticatePESU(username, password):
+def authenticatePESU(username, password, get_profile_data):
     chrome = webdriver.Chrome(
         executable_path=CHROMEDRIVER_PATH, options=chrome_options)
     chrome.get("https://pesuacademy.com/Academy")
-    time.sleep(2)
+    time.sleep(1)
 
     username_box = chrome.find_element_by_xpath(r'//*[@id="j_scriptusername"]')
     password_box = chrome.find_element_by_xpath(r'//*[@name="j_password"]')
@@ -41,12 +41,16 @@ def authenticatePESU(username, password):
     try:
         menu_options = chrome.find_elements_by_xpath(
             r'//*[@class="menu-name"]')
-        menu_options[9].click()
+        
+        for menu_option in menu_options:
+            if menu_option.text == "My Profile":
+                break
+        menu_option.click()
         login_status = True
     except:
         login_status = False
 
-    if login_status:
+    if login_status and get_profile_data:
         time.sleep(1)
         text_boxes = chrome.find_elements_by_xpath(
             r'//*[@class="col-md-12 col-xs-12 control-label text-left"]')


### PR DESCRIPTION
Option flags allow you to only authenticate and will later allow code segments to retrieve other information only if the flag has been set. No need to retrieve all information if not required for authentication purposes.